### PR TITLE
Use X-Forward-For address in the logs instead of local ALB address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,6 @@ COPY ./src/stac_fastapi /var/task/stac_fastapi
 
 CMD ["uvicorn", "stac_fastapi.globus_search.app:handler", \
      "--host", "0.0.0.0", "--port", "8000", \
+     "--forwarded-allow-ips", "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16", \
      "--ssl-keyfile", "/etc/ssl/discovery/server.key", \
      "--ssl-certfile", "/etc/ssl/discovery/server.crt"]


### PR DESCRIPTION
Currently the ECS logs generated by uvicorn show a local ALB address as a client address:

`INFO: 10.42.1.232:35682 - "GET / HTTP/1.1" 200 OK`

Adding `--forwarded-allow-ips 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16` tells uvicorn to use a client address sent by ALB in `X-Forwarded-For` header, e.g.:

`INFO: 104.23.118.224:0 - "GET / HTTP/1.1" 200 OK`
