### PR TITLE
Reduce production request latency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ COPY ./src/stac_fastapi /var/task/stac_fastapi
 
 CMD ["uvicorn", "stac_fastapi.globus_search.app:handler", \
      "--host", "0.0.0.0", "--port", "8000", \
+     "--workers", "2", \
      "--forwarded-allow-ips", "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16", \
      "--ssl-keyfile", "/etc/ssl/discovery/server.key", \
      "--ssl-certfile", "/etc/ssl/discovery/server.crt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN esgvoc use cmip6@latest \
 COPY ./src/stac_fastapi /var/task/stac_fastapi
 
 CMD ["uvicorn", "stac_fastapi.globus_search.app:handler", \
-     "--host", "0.0.0.0", "--port", "8000", \
-     "--workers", "2", \
+     "--host", "0.0.0.0", "--port", "8000",
      "--forwarded-allow-ips", "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16", \
      "--ssl-keyfile", "/etc/ssl/discovery/server.key", \
      "--ssl-certfile", "/etc/ssl/discovery/server.crt"]

--- a/src/stac_fastapi/globus_search/app.py
+++ b/src/stac_fastapi/globus_search/app.py
@@ -81,7 +81,7 @@ api = StacApi(
 )
 handler = ASGICacheMiddleware(
     api.app,
-    storage=AsyncSqliteStorage(database_path=f"/tmp/hishel_cache_{os.getpid()}.db"),
+    storage=AsyncSqliteStorage(database_path=f"/tmp/hishel_cache.db"),
 )
 
 

--- a/src/stac_fastapi/globus_search/app.py
+++ b/src/stac_fastapi/globus_search/app.py
@@ -3,6 +3,8 @@ This app definition is a fork of the one from the Mongo backend for
 stac-fastapi.
 """
 
+import os
+
 from hishel import AsyncSqliteStorage
 from hishel.asgi import ASGICacheMiddleware
 from hishel.fastapi import cache
@@ -79,7 +81,7 @@ api = StacApi(
 )
 handler = ASGICacheMiddleware(
     api.app,
-    storage=AsyncSqliteStorage(database_path="cache/hishel_cache.db"),
+    storage=AsyncSqliteStorage(database_path=f"/tmp/hishel_cache_{os.getpid()}.db"),
 )
 
 

--- a/src/stac_fastapi/globus_search/core.py
+++ b/src/stac_fastapi/globus_search/core.py
@@ -1,13 +1,89 @@
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 from fastapi import HTTPException
 from stac_fastapi.core.core import CoreClient
 from stac_fastapi.core.models.links import PagingLinks
 from stac_fastapi.types import stac as stac_types
+from stac_fastapi.types.requests import get_base_url
+from stac_pydantic.links import Relations
+from stac_pydantic.shared import MimeTypes
+from starlette.concurrency import run_in_threadpool
+
+from stac_fastapi.globus_search.utility import list_project_summaries
 
 
 class GlobusSearchClient(CoreClient):
+    async def landing_page(self, **kwargs) -> stac_types.LandingPage:
+        """Landing page."""
+        request = kwargs["request"]
+        base_url = get_base_url(request)
+        landing_page = self._landing_page(
+            base_url=base_url,
+            conformance_classes=self.conformance_classes(),
+            extension_schemas=[],
+        )
+
+        if self.extension_is_enabled("FilterExtension"):
+            landing_page["links"].append(
+                {
+                    "rel": "queryables",
+                    "type": "application/schema+json",
+                    "title": "Queryables",
+                    "href": urljoin(base_url, "queryables"),
+                }
+            )
+
+        if self.extension_is_enabled("AggregationExtension"):
+            landing_page["links"].extend(
+                [
+                    {
+                        "rel": "aggregate",
+                        "type": "application/json",
+                        "title": "Aggregate",
+                        "href": urljoin(base_url, "aggregate"),
+                    },
+                    {
+                        "rel": "aggregations",
+                        "type": "application/json",
+                        "title": "Aggregations",
+                        "href": urljoin(base_url, "aggregations"),
+                    },
+                ]
+            )
+
+        projects = await run_in_threadpool(list_project_summaries)
+        for project in projects:
+            landing_page["links"].append(
+                {
+                    "rel": Relations.child.value,
+                    "type": MimeTypes.json.value,
+                    "title": project.get("title") or project["id"],
+                    "href": urljoin(base_url, f"collections/{project['id']}"),
+                }
+            )
+
+        landing_page["links"].append(
+            {
+                "rel": "service-desc",
+                "type": "application/vnd.oai.openapi+json;version=3.0",
+                "title": "OpenAPI service description",
+                "href": urljoin(
+                    str(request.base_url), request.app.openapi_url.lstrip("/")
+                ),
+            }
+        )
+        landing_page["links"].append(
+            {
+                "rel": "service-doc",
+                "type": "text/html",
+                "title": "OpenAPI service documentation",
+                "href": urljoin(str(request.base_url), request.app.docs_url.lstrip("/")),
+            }
+        )
+
+        return landing_page
+
     async def get_collection(
         self, collection_id: str, **kwargs
     ) -> stac_types.Collection:

--- a/src/stac_fastapi/globus_search/database_logic.py
+++ b/src/stac_fastapi/globus_search/database_logic.py
@@ -3,14 +3,13 @@ This definition is a fork of the one from the Mongo backend for
 stac-fastapi, modified to work on Globus Search.
 """
 
-import json
-import os
 import typing as t
 
 import attrs
 import globus_sdk
 from fastapi import HTTPException
 from stac_fastapi.core import serializers
+from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 
 from .config import settings
@@ -242,7 +241,9 @@ class DatabaseLogic:
         return list_projects()
 
     async def get_one_item(self, collection_id: str, item_id: str) -> dict:
-        res = _client.get_subject(settings.search_index_id, item_id)
+        res = await run_in_threadpool(
+            _client.get_subject, settings.search_index_id, item_id
+        )
         return search_doc_to_stac_item(res.data)
 
     @staticmethod
@@ -334,7 +335,9 @@ class DatabaseLogic:
         if token:
             search.set_marker(token)
         try:
-            response = _client.scroll(settings.search_index_id, search)
+            response = await run_in_threadpool(
+                _client.scroll, settings.search_index_id, search
+            )
         except globus_sdk.SearchAPIError as e:
             print("SearchAPIError:")
             print(e.text)

--- a/src/stac_fastapi/globus_search/database_logic.py
+++ b/src/stac_fastapi/globus_search/database_logic.py
@@ -233,12 +233,12 @@ class DatabaseLogic:
     )
 
     async def find_collection(self, collection_id: str) -> dict:
-        return get_project(collection_id)
+        return await run_in_threadpool(get_project, collection_id)
 
     async def get_all_collections(
         self, token: str | None, limit: int, request: Request
     ) -> tuple[list[dict[str, t.Any]], str | None]:
-        return list_projects()
+        return await run_in_threadpool(list_projects)
 
     async def get_one_item(self, collection_id: str, item_id: str) -> dict:
         res = await run_in_threadpool(

--- a/src/stac_fastapi/globus_search/extensions/aggregration/client.py
+++ b/src/stac_fastapi/globus_search/extensions/aggregration/client.py
@@ -16,6 +16,7 @@ from stac_fastapi.core.extensions.aggregation import EsAggregationExtensionPostR
 from stac_fastapi.core.session import Session
 from stac_fastapi.extensions.core.aggregation.client import BaseAggregationClient
 from stac_fastapi.extensions.core.aggregation.types import AggregationCollection
+from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 
 from stac_fastapi.globus_search.config import settings
@@ -681,7 +682,9 @@ class GlobusSearchAggregationClient(BaseAggregationClient):
 
         for aggregation in aggregations:
             if aggregation == "total_count":
-                response = self.client.post_search(settings.search_index_id, search)
+                response = await run_in_threadpool(
+                    self.client.post_search, settings.search_index_id, search
+                )
                 return {
                     "type": "AggregationCollection",
                     "aggregations": [
@@ -715,7 +718,9 @@ class GlobusSearchAggregationClient(BaseAggregationClient):
                     size=size,
                 )
 
-        response = self.client.post_search(settings.search_index_id, search)
+        response = await run_in_threadpool(
+            self.client.post_search, settings.search_index_id, search
+        )
 
         if response["facet_results"]:
             for facet in response["facet_results"]:

--- a/src/stac_fastapi/globus_search/utility.py
+++ b/src/stac_fastapi/globus_search/utility.py
@@ -1,10 +1,13 @@
 import json
+import logging
 from copy import deepcopy
 from functools import lru_cache
 
 import esgvoc.api.projects as ev
 from esgvoc.api.project_specs import DrsType
 from esgvoc.apps.jsg.json_schema_generator import generate_json_schema
+
+logger = logging.getLogger(__name__)
 
 
 def _extract_summaries_from_schema(schema: dict) -> dict:
@@ -149,7 +152,37 @@ def get_project(project_id: str = "cmip6") -> dict:
 
 
 @lru_cache(maxsize=1)
-def _build_projects() -> tuple[list[dict], None]:
+def _build_project_summaries() -> list[dict[str, str]]:
+    """
+    Build lightweight project metadata for landing-page collection links.
+
+    This intentionally avoids generate_json_schema(), which is only needed for
+    full STAC Collection documents.
+    """
+    results = []
+
+    for project_id in ev.get_all_projects():
+        specs = ev.get_project(project_id.lower())
+        if specs is None:
+            logger.warning("Skipping '%s': project not found in esgvoc", project_id)
+            continue
+        if specs.catalog_specs is None:
+            logger.warning(
+                "Skipping '%s': project has no catalog_specs", project_id
+            )
+            continue
+
+        results.append({"id": specs.project_id, "title": specs.drs_name})
+
+    return results
+
+
+def list_project_summaries() -> list[dict[str, str]]:
+    return deepcopy(_build_project_summaries())
+
+
+@lru_cache(maxsize=1)
+def _build_projects() -> list[dict]:
     """
     Build the full project list once per process.
 
@@ -163,9 +196,9 @@ def _build_projects() -> tuple[list[dict], None]:
             results.append(_build_project(project_id))
         except ValueError as e:
             # Skip projects with missing catalog_specs or not yet fully configured
-            print(f"Skipping '{project_id}': {e}")
+            logger.warning("Skipping '%s': %s", project_id, e)
 
-    return results, None
+    return results
 
 
 def list_projects() -> tuple[list[dict], None]:
@@ -176,7 +209,7 @@ def list_projects() -> tuple[list[dict], None]:
     Returns the same structure as build_stac_collection() for each project,
     i.e. [{cmip6 collection...}, {obs4mips collection...}, ...]
     """
-    return deepcopy(_build_projects())
+    return deepcopy(_build_projects()), None
 
 
 if __name__ == "__main__":

--- a/src/stac_fastapi/globus_search/utility.py
+++ b/src/stac_fastapi/globus_search/utility.py
@@ -1,4 +1,6 @@
 import json
+from copy import deepcopy
+from functools import lru_cache
 
 import esgvoc.api.projects as ev
 from esgvoc.api.project_specs import DrsType
@@ -46,7 +48,8 @@ def _extract_summaries_from_schema(schema: dict) -> dict:
     return summaries
 
 
-def get_project(project_id: str = "cmip6") -> dict:
+@lru_cache(maxsize=None)
+def _build_project(project_id: str = "cmip6") -> dict:
     """
     Generate a STAC-compliant Collection for an ESGF project.
     Summaries are derived entirely from generate_json_schema() via catalog_specs —
@@ -141,7 +144,31 @@ def get_project(project_id: str = "cmip6") -> dict:
     }
 
 
-def list_projects() -> list[dict]:
+def get_project(project_id: str = "cmip6") -> dict:
+    return deepcopy(_build_project(project_id))
+
+
+@lru_cache(maxsize=1)
+def _build_projects() -> tuple[list[dict], None]:
+    """
+    Build the full project list once per process.
+
+    Collection responses are mutated downstream when links are normalized, so public
+    accessors return deep copies instead of the cached objects.
+    """
+    results = []
+
+    for project_id in ev.get_all_projects():
+        try:
+            results.append(_build_project(project_id))
+        except ValueError as e:
+            # Skip projects with missing catalog_specs or not yet fully configured
+            print(f"Skipping '{project_id}': {e}")
+
+    return results, None
+
+
+def list_projects() -> tuple[list[dict], None]:
     """
     Return a full STAC Collection document for every project available
     in the local esgvoc installation.
@@ -149,16 +176,7 @@ def list_projects() -> list[dict]:
     Returns the same structure as build_stac_collection() for each project,
     i.e. [{cmip6 collection...}, {obs4mips collection...}, ...]
     """
-    results = []
-
-    for project_id in ev.get_all_projects():
-        try:
-            results.append(get_project(project_id))
-        except ValueError as e:
-            # Skip projects with missing catalog_specs or not yet fully configured
-            print(f"Skipping '{project_id}': {e}")
-
-    return results, None
+    return deepcopy(_build_projects())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- offload synchronous Globus SDK network calls from async request handlers into Starlette's threadpool
- cache expensive ESGVOC collection construction while returning deep copies to avoid shared response mutation
- move Hishel's SQLite cache to per-process /tmp files and run production Uvicorn with two workers

## Latest updates
- override the landing page handler so `/` uses lightweight ESGVOC project metadata instead of building full STAC Collection documents
- add cached `list_project_summaries()` for homepage child collection links without calling `generate_json_schema()`
- move synchronous ESGVOC collection lookups through Starlette's threadpool to avoid blocking the async event loop
- keep `/collections` and `/collections/{collection_id}` on the full collection-document path

## Why
Production ECS requests were seeing roughly 4s time to first byte. The main code-level risk was sync Globus SDK I/O running inside async FastAPI handlers on a single Uvicorn worker, which can block the ASGI event loop and delay response headers under load. The collection metadata path also rebuilt ESGVOC-derived STAC collections per request, and the SQLite cache file could become a cross-worker contention point.

The latest updates further reduce homepage latency by avoiding full ESGVOC-backed collection document generation on `/`. The homepage only needs collection IDs and titles for child links, so it now uses lightweight ESGVOC metadata while preserving full collection responses on the collection endpoints.

## Follow-up
- redeploy and compare ECS TTFB before/after under concurrency
- tune Uvicorn worker count based on ECS CPU and load testing
- if latency remains high, temporarily disable Hishel cache middleware to isolate cache overhead
