### PR TITLE
Expand unit test coverage to 100%

### DIFF
--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 from fastapi import HTTPException
+from stac_fastapi.extensions.core import AggregationExtension, FilterExtension
 from starlette.requests import Request
 
 from stac_fastapi.globus_search import core as core_module
@@ -25,6 +26,33 @@ def _request(
             "scheme": scheme,
             "server": (host, 443),
             "client": ("testclient", 50000),
+        }
+    )
+
+
+def _request_with_app(
+    path="/",
+    host="api.example.org",
+    scheme="https",
+    openapi_url="/openapi.json",
+    docs_url="/docs",
+):
+    fake_app = SimpleNamespace(
+        state=SimpleNamespace(router_prefix=""),
+        openapi_url=openapi_url,
+        docs_url=docs_url,
+    )
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [(b"host", host.encode())],
+            "query_string": b"",
+            "scheme": scheme,
+            "server": (host, 443),
+            "client": ("testclient", 50000),
+            "app": fake_app,
         }
     )
 
@@ -80,8 +108,11 @@ class FakeDatabase:
         return self.items, self.total, self.next_marker
 
 
-def _client(database=None):
-    return GlobusSearchClient(database=database or FakeDatabase())
+def _client(database=None, extensions=None):
+    return GlobusSearchClient(
+        database=database or FakeDatabase(),
+        extensions=extensions or [],
+    )
 
 
 @pytest.mark.parametrize(
@@ -376,3 +407,90 @@ def test_post_search_wraps_free_text_errors_in_http_400():
 
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail == "Error with free-text query: bad q"
+
+
+def test_landing_page_includes_service_links(monkeypatch):
+    monkeypatch.setattr(core_module, "list_project_summaries", lambda: [])
+
+    page = asyncio.run(_client().landing_page(request=_request_with_app()))
+
+    service_desc = next(l for l in page["links"] if l["rel"] == "service-desc")
+    assert service_desc["href"] == "https://api.example.org/openapi.json"
+    service_doc = next(l for l in page["links"] if l["rel"] == "service-doc")
+    assert service_doc["href"] == "https://api.example.org/docs"
+
+
+def test_landing_page_adds_child_link_for_each_project(monkeypatch):
+    monkeypatch.setattr(
+        core_module,
+        "list_project_summaries",
+        lambda: [{"id": "cmip6", "title": "CMIP6"}, {"id": "obs4mips", "title": "obs4MIPs"}],
+    )
+
+    page = asyncio.run(_client().landing_page(request=_request_with_app()))
+
+    child_links = [l for l in page["links"] if l["rel"] == "child"]
+    assert len(child_links) == 2
+    assert child_links[0]["href"] == "https://api.example.org/collections/cmip6"
+    assert child_links[0]["title"] == "CMIP6"
+    assert child_links[1]["href"] == "https://api.example.org/collections/obs4mips"
+    assert child_links[1]["title"] == "obs4MIPs"
+
+
+def test_landing_page_uses_project_id_as_title_when_title_is_absent(monkeypatch):
+    monkeypatch.setattr(
+        core_module, "list_project_summaries", lambda: [{"id": "cmip6"}]
+    )
+
+    page = asyncio.run(_client().landing_page(request=_request_with_app()))
+
+    child_link = next(l for l in page["links"] if l["rel"] == "child")
+    assert child_link["title"] == "cmip6"
+
+
+def test_landing_page_adds_queryables_link_when_filter_extension_is_enabled(monkeypatch):
+    monkeypatch.setattr(core_module, "list_project_summaries", lambda: [])
+
+    page = asyncio.run(
+        _client(extensions=[FilterExtension()]).landing_page(
+            request=_request_with_app()
+        )
+    )
+
+    queryables_links = [l for l in page["links"] if l["rel"] == "queryables"]
+    assert len(queryables_links) == 1
+    assert queryables_links[0]["href"] == "https://api.example.org/queryables"
+
+
+def test_landing_page_omits_queryables_link_without_filter_extension(monkeypatch):
+    monkeypatch.setattr(core_module, "list_project_summaries", lambda: [])
+
+    page = asyncio.run(_client().landing_page(request=_request_with_app()))
+
+    assert not any(l["rel"] == "queryables" for l in page["links"])
+
+
+def test_landing_page_adds_aggregate_links_when_aggregation_extension_is_enabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(core_module, "list_project_summaries", lambda: [])
+
+    page = asyncio.run(
+        _client(extensions=[AggregationExtension()]).landing_page(
+            request=_request_with_app()
+        )
+    )
+
+    aggregate = next(l for l in page["links"] if l["rel"] == "aggregate")
+    assert aggregate["href"] == "https://api.example.org/aggregate"
+    aggregations = next(l for l in page["links"] if l["rel"] == "aggregations")
+    assert aggregations["href"] == "https://api.example.org/aggregations"
+
+
+def test_landing_page_omits_aggregate_links_without_aggregation_extension(monkeypatch):
+    monkeypatch.setattr(core_module, "list_project_summaries", lambda: [])
+
+    page = asyncio.run(_client().landing_page(request=_request_with_app()))
+
+    assert not any(l["rel"] == "aggregate" for l in page["links"])
+    assert not any(l["rel"] == "aggregations" for l in page["links"])

--- a/tests/unit/test_database_logic.py
+++ b/tests/unit/test_database_logic.py
@@ -1,4 +1,5 @@
 import asyncio
+from unittest.mock import MagicMock
 
 import globus_sdk
 import pytest
@@ -520,3 +521,57 @@ def test_execute_search_sets_pagination_token(monkeypatch):
     )
 
     assert result == ([], 0, None)
+
+
+def test_cql_like_to_globus_like_raises_on_trailing_escape():
+    with pytest.raises(ValueError, match="cannot end with an escape character"):
+        cql_like_to_globus_like("hist\\")
+
+
+def test_cql_to_filter_raises_value_error_for_like_with_non_string_pattern():
+    with pytest.raises(ValueError, match="requires a string pattern"):
+        cql_to_filter({"op": "like", "args": [{"property": "activity_id"}, 42]})
+
+
+def test_apply_cql2_filter_detects_collection_prefix_past_non_matching_filters():
+    search = globus_sdk.SearchQuery()
+    search["filters"] = [
+        {"type": "exists", "field_name": "id"},
+        {"type": "match_any", "field_name": "collection", "values": ["CMIP6"]},
+    ]
+
+    DatabaseLogic.apply_cql2_filter(
+        search, {"op": "like", "args": [{"property": "experiment_id"}, "hist%"]}
+    )
+
+    assert search["filters"][-1] == {
+        "type": "like",
+        "field_name": "properties.cmip6:experiment_id",
+        "value": "hist*",
+    }
+
+
+def test_execute_search_propagates_search_api_error(monkeypatch):
+    r = MagicMock()
+    r.status_code = 503
+    r.headers = {"Content-Type": "text/plain"}
+    r.text = "service unavailable"
+    r.json.side_effect = ValueError("not json")
+    api_error = globus_sdk.SearchAPIError(r)
+
+    class FakeClient:
+        def scroll(self, index_id, search):
+            raise api_error
+
+    monkeypatch.setattr(database_logic, "_client", FakeClient())
+
+    with pytest.raises(globus_sdk.SearchAPIError):
+        asyncio.run(
+            DatabaseLogic().execute_search(
+                search=globus_sdk.SearchScrollQuery(),
+                limit=10,
+                token=None,
+                sort=None,
+                collection_ids=None,
+            )
+        )

--- a/tests/unit/test_utility.py
+++ b/tests/unit/test_utility.py
@@ -207,3 +207,68 @@ def test_list_projects_returns_collections_and_skips_invalid_projects(
     assert results == [{"id": "cmip6"}]
     assert token is None
     assert "Skipping 'bad': not configured" in caplog.text
+
+
+def _project_summary_specs(project_id, drs_name, *, has_catalog_specs=True):
+    return SimpleNamespace(
+        project_id=project_id,
+        drs_name=drs_name,
+        catalog_specs=object() if has_catalog_specs else None,
+    )
+
+
+def test_list_project_summaries_returns_id_and_title_for_each_project(monkeypatch):
+    monkeypatch.setattr(utility.ev, "get_all_projects", lambda: ["cmip6", "obs4mips"])
+
+    def fake_get_project(project_id):
+        return {
+            "cmip6": _project_summary_specs("cmip6", "CMIP6"),
+            "obs4mips": _project_summary_specs("obs4mips", "obs4MIPs"),
+        }[project_id]
+
+    monkeypatch.setattr(utility.ev, "get_project", fake_get_project)
+
+    result = utility.list_project_summaries()
+
+    assert result == [
+        {"id": "cmip6", "title": "CMIP6"},
+        {"id": "obs4mips", "title": "obs4MIPs"},
+    ]
+
+
+def test_list_project_summaries_skips_projects_not_found_in_esgvoc(
+    monkeypatch, caplog
+):
+    monkeypatch.setattr(utility.ev, "get_all_projects", lambda: ["cmip6", "unknown"])
+
+    def fake_get_project(project_id):
+        if project_id == "unknown":
+            return None
+        return _project_summary_specs("cmip6", "CMIP6")
+
+    monkeypatch.setattr(utility.ev, "get_project", fake_get_project)
+
+    result = utility.list_project_summaries()
+
+    assert result == [{"id": "cmip6", "title": "CMIP6"}]
+    assert "Skipping 'unknown': project not found in esgvoc" in caplog.text
+
+
+def test_list_project_summaries_skips_projects_without_catalog_specs(
+    monkeypatch, caplog
+):
+    monkeypatch.setattr(
+        utility.ev, "get_all_projects", lambda: ["cmip6", "incomplete"]
+    )
+
+    def fake_get_project(project_id):
+        if project_id == "incomplete":
+            return _project_summary_specs("incomplete", "Incomplete", has_catalog_specs=False)
+        return _project_summary_specs("cmip6", "CMIP6")
+
+    monkeypatch.setattr(utility.ev, "get_project", fake_get_project)
+
+    result = utility.list_project_summaries()
+
+    assert result == [{"id": "cmip6", "title": "CMIP6"}]
+    assert "Skipping 'incomplete': project has no catalog_specs" in caplog.text


### PR DESCRIPTION
## Summary

- **`test_core.py`**: Added 7 tests for the previously uncovered `landing_page` method — service-desc/service-doc links, project child links, title fallback to project ID, and conditional `FilterExtension`/`AggregationExtension` links
- **`test_database_logic.py`**: Added 4 tests covering trailing-escape error in `cql_like_to_globus_like`, non-string pattern rejection in the `like` filter, the multi-filter loop branch in `_extract_collection_ids`, and `SearchAPIError` propagation in `execute_search`
- **`test_utility.py`**: Added 3 tests for `list_project_summaries` — the happy path and both skip/warn branches (project not found in esgvoc, project missing `catalog_specs`)

## Result

Coverage goes from 93% to 100% across all source files (501 statements, 182 branches). All 136 tests pass.

## Test plan

- Run `pytest tests/unit/` and confirm 136 tests pass with 0 failures
- Run `coverage report` and confirm 100% coverage for all files under `src/stac_fastapi/globus_search/`

Generated with [Claude Code](https://claude.com/claude-code)